### PR TITLE
Improve extrema detection flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ changepoints = detector.detect_comprehensive(weekly_data.values)
 
 # 3. 峰谷分类
 classifier = ExtremaClassifier()
-peaks, troughs = classifier.classify_changepoints(weekly_data, changepoints)
+peaks, troughs = classifier.classify_changepoints(
+    weekly_data,
+    changepoints,
+    window=1,        # 较小窗口更快确认
+    check_right=False  # 仅检查左侧，提前锁定极值
+)
 
 # 4. 可视化
 visualizer = MultiLayerVisualizer()
@@ -217,6 +222,14 @@ changepoints = detector.detect_sd_bocpd(
     beta=0.90,        # 方差持续性
     hazard_rate=1/25, # 变点先验概率
     threshold=0.3     # 检测阈值
+)
+
+# 调整峰谷分类窗口与方向
+peaks, troughs = ExtremaClassifier.classify_changepoints(
+    series,
+    changepoints,
+    window=0,        # 仅判定左侧
+    check_right=False
 )
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,20 @@ visualizer.plot_changepoint_analysis(weekly_data, changepoints)
 
 查看 `examples/` 目录获取更多使用示例。
 
+## 高级参数调节
+
+在需要更快速的峰谷确认时，可以调整 `ExtremaClassifier.classify_changepoints`
+ 的 `window` 和 `check_right` 参数：
+
+```python
+peaks, troughs = ExtremaClassifier.classify_changepoints(
+    weekly_data,
+    changepoints,
+    window=0,        # 只检查左侧数据
+    check_right=False
+)
+```
+
 ## 测试
 
 ```bash

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -55,7 +55,10 @@ def basic_example():
         # 峰谷分类
         classifier = ExtremaClassifier()
         macro_peaks_dt, macro_troughs_dt = classifier.classify_changepoints(
-            wk_series, cp_indices, window=2
+            wk_series,
+            cp_indices,
+            window=1,  # 缩小窗口提高响应速度
+            check_right=False,
         )
         
         # 3. 中观层检测 (日线)


### PR DESCRIPTION
## Summary
- allow single-sided extrema detection
- expose `check_right` parameter in change point classification
- update example usage and docs to demonstrate faster detection
- document advanced parameter tuning in README and docs

## Testing
- `pytest -o addopts='' -q`

------
https://chatgpt.com/codex/tasks/task_e_68550b0c54308330acf9d44a8fd5238e